### PR TITLE
image-to-ascii-cli 1.0.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ Contributions are more than welcome!
 
 Thanks! :sweat_smile:
 
+
+
 [1]: https://github.com/IonicaBizau/image-to-ascii-cli/issues
 
 [2]: https://github.com/IonicaBizau/code-style

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,6 @@
+## Documentation
+
+You can see below the API reference of this module.
+
+### exports
+

--- a/README.md
+++ b/README.md
@@ -1,42 +1,52 @@
-# `$ image-to-ascii` [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/image-to-ascii-cli.svg)](https://www.npmjs.com/package/image-to-ascii-cli) [![Downloads](https://img.shields.io/npm/dt/image-to-ascii-cli.svg)](https://www.npmjs.com/package/image-to-ascii-cli) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+
+# `$ image-to-ascii`
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/image-to-ascii-cli.svg)](https://www.npmjs.com/package/image-to-ascii-cli) [![Downloads](https://img.shields.io/npm/dt/image-to-ascii-cli.svg)](https://www.npmjs.com/package/image-to-ascii-cli) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > View images in text format, in your terminal.
 
 ## :cloud: Installation
-    
+
 You can install the package globally and use it as command line tool:
+
 
 ```sh
 $ npm i -g image-to-ascii-cli
 ```
-    
+
 :bulb: **ProTip**: If you want to use this package as module, check out [`image-to-ascii`—the API version of it](http://github.com/IonicaBizau/image-to-ascii).
-    
+
 
 Then, run `image-to-ascii --help` and see what the CLI tool can do.
 
-    
+
 ```
 $ image-to-ascii --help
 Usage: image-to-ascii-cli [options]
 
 Options:
-  -i, --img <path>  Image path                   
-  -h, --help        Displays this help.          
+  -i, --img <path>  Image path
+  -h, --help        Displays this help.
   -v, --version     Displays version information.
 
 Examples:
   image-to-ascii -i path/to/some/image.png
 
+
 ```
-    
+
+## :memo: Documentation
+
+For full API reference, see the [DOCUMENTATION.md][docs] file.
+
 ## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
+
 ## :scroll: License
-    
+
 [MIT][license] © [Ionică Bizău][website]
-    
+
 [paypal-donations]: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RVXDDLKKLQRJW
 [donate-now]: http://i.imgur.com/6cMbHOC.png
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-to-ascii-cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "View images in text format, in your terminal.",
   "main": "lib/index.js",
   "bin": {
@@ -29,5 +29,17 @@
   "homepage": "https://github.com/IonicaBizau/image-to-ascii-cli#readme",
   "blah": {
     "api": "image-to-ascii"
-  }
+  },
+  "files": [
+    "bin/",
+    "app/",
+    "lib/",
+    "dist/",
+    "src/",
+    "resources/",
+    "menu/",
+    "scripts/",
+    "cli.js",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
